### PR TITLE
deps: depend on node-sqlite3 from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.1.1",
     "loopback-connector": "2.x",
     "moment": "^2.10.3",
-    "sqlite3": "^3.0.6"
+    "sqlite3": "mapbox/node-sqlite3#5a2939d"
   },
   "devDependencies": {
     "bluebird": "^2.9.12",


### PR DESCRIPTION
The commit is marked as 3.0.11 but has not yet been tagged and released.

The only change in it is the upgrade to nan@2, which allows building against iojs-v3 and node-v4.

See https://github.com/mapbox/node-sqlite3/commit/5a2939d0f1a0929c0541a2a8dce327dc38d26421

Note that this does not fix the failing tests, only the failing install.

Basically the same patch as strongloop/minkelite#22 /cc @kraman 