### PR TITLE
deps: use official sqlite3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.1.1",
     "loopback-connector": "2.x",
     "moment": "^2.10.3",
-    "sqlite3": "mapbox/node-sqlite3#5a2939d"
+    "sqlite3": "^3.1.0"
   },
   "devDependencies": {
     "bluebird": "^2.9.12",


### PR DESCRIPTION
3.1.0 was released with support for iojs-3/node-4.